### PR TITLE
Refactor AI analyzer tests to use a single mock target

### DIFF
--- a/tests/test_ai_estate_analysis.py
+++ b/tests/test_ai_estate_analysis.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from unittest.mock import patch
 
+from httpx import ConnectError
+
 from src.ai_analyzer import analyze_estate_relevant_information
 
 
@@ -10,7 +12,10 @@ def _build_response(payload: dict) -> dict:
     return {"message": {"content": json.dumps(payload)}}
 
 
-def test_analyze_estate_single_chunk_extracts_information():
+@patch("src.ai_analyzer._ollama_chat")
+def test_analyze_estate_single_chunk_extracts_information(
+    mock_ollama_chat,
+):
     sample_text = (
         "My will is kept in the blue folder in the study desk. "
         "Contact Attorney Lisa Grant at 555-1234 for probate."
@@ -25,22 +30,24 @@ def test_analyze_estate_single_chunk_extracts_information():
             }
         ]
     }
+    mock_ollama_chat.return_value = _build_response(mocked_payload)
 
-    with patch(
-        "src.ai_analyzer.ollama.chat", return_value=_build_response(mocked_payload)
-    ) as mock_chat:
-        result = analyze_estate_relevant_information(
-            sample_text, source_name="letter.txt"
-        )
+    result = analyze_estate_relevant_information(
+        sample_text, source_name="letter.txt"
+    )
 
     assert result["has_estate_relevant_info"] is True
     assert "Legal" in result["estate_information"]
     assert result["estate_information"]["Legal"][0]["item"] == "Last Will and Testament"
     assert result["_chunk_count"] == 1
-    mock_chat.assert_called_once()
+    mock_ollama_chat.assert_called_once()
 
 
-def test_analyze_estate_multi_chunk_merges_results():
+@patch("src.ai_analyzer.chunk_text", return_value=["chunk-1", "chunk-2"])
+@patch("src.ai_analyzer._ollama_chat")
+def test_analyze_estate_multi_chunk_merges_results(
+    mock_ollama_chat, _mock_chunk_text
+):
     long_text = "x" * 4005
     chunk_payloads = [
         {
@@ -65,17 +72,12 @@ def test_analyze_estate_multi_chunk_merges_results():
             ]
         },
     ]
+    side_effect = [_build_response(payload) for payload in chunk_payloads]
+    mock_ollama_chat.side_effect = side_effect
 
-    with (
-        patch("src.ai_analyzer.chunk_text", return_value=["chunk-1", "chunk-2"]),
-        patch(
-            "src.ai_analyzer.ollama.chat",
-            side_effect=[_build_response(payload) for payload in chunk_payloads],
-        ) as mock_chat,
-    ):
-        result = analyze_estate_relevant_information(
-            long_text, source_name="vault-notes.txt"
-        )
+    result = analyze_estate_relevant_information(
+        long_text, source_name="vault-notes.txt"
+    )
 
     assert result["has_estate_relevant_info"] is True
     assert "Financial" in result["estate_information"]
@@ -83,18 +85,32 @@ def test_analyze_estate_multi_chunk_merges_results():
     assert len(result["estate_information"]["Financial"]) == 1
     assert len(result["estate_information"]["Digital"]) == 1
     assert result["_chunk_count"] == 2
-    assert mock_chat.call_count == 2
+    assert mock_ollama_chat.call_count == 2
 
 
-def test_analyze_estate_returns_default_on_llm_failure():
+@patch("src.ai_analyzer._ollama_chat")
+def test_analyze_estate_returns_default_on_llm_failure(
+    mock_ollama_chat,
+):
     sample_text = "Funeral wishes are detailed in my notebook."
+    mock_ollama_chat.side_effect = RuntimeError("LLM unavailable")
 
-    with patch(
-        "src.ai_analyzer.ollama.chat", side_effect=RuntimeError("LLM unavailable")
-    ):
-        result = analyze_estate_relevant_information(
-            sample_text, source_name="notes.txt"
-        )
+    result = analyze_estate_relevant_information(
+        sample_text, source_name="notes.txt"
+    )
+
+    assert result["has_estate_relevant_info"] is False
+    assert result["estate_information"] == {}
+    assert result["_chunk_count"] == 0
+
+
+@patch("src.ai_analyzer._ollama_chat")
+def test_analyze_estate_handles_connection_error(mock_ollama_chat):
+    mock_ollama_chat.side_effect = ConnectError("Connection failed")
+
+    result = analyze_estate_relevant_information(
+        "test text", source_name="connect_error.txt"
+    )
 
     assert result["has_estate_relevant_info"] is False
     assert result["estate_information"] == {}


### PR DESCRIPTION
The existing tests for the AI analyzer were failing and slow due to their reliance on a live Ollama service. They were also using a dual-mocking strategy that was difficult to maintain and understand.

This change refactors the tests to use a single, correct mock target, `src.ai_analyzer._ollama_chat`. This makes the tests more robust, reliable, and easier to maintain. The tests now run much faster and no longer require a live Ollama service.