### PR TITLE
Add summary field coercion to JSON strings in FileRecord model

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -25,3 +25,18 @@ def test_file_record_defaults():
     assert record.potential_red_flags == []
     assert record.incriminating_items == []
     assert record.confidence_score is None
+
+
+def test_file_record_summary_coerces_structured_data():
+    record = FileRecord.model_validate(  # type: ignore[arg-type]
+        {
+            "file_path": "/path/to/file.txt",
+            "file_name": "file.txt",
+            "mime_type": "text/plain",
+            "file_size": 123,
+            "last_modified": 1678886400.0,
+            "sha256": "a1b2c3d4",
+            "summary": {"name": "John", "favorite_food": "Pizza"},
+        }
+    )
+    assert record.summary == '{"favorite_food": "Pizza", "name": "John"}'


### PR DESCRIPTION
Implement coercion for the summary field in the FileRecord model to convert structured data into JSON strings. This change enhances compatibility with legacy manifests.