### PR TITLE
The analysis pipeline was previously skipping legacy Excel files (.xl…

### DIFF
--- a/main.py
+++ b/main.py
@@ -2592,6 +2592,7 @@ def main(
                 or file_record.mime_type == "image/svg+xml"
                 or file_record.mime_type.endswith("document")
                 or file_record.mime_type.endswith("sheet")
+                or file_record.mime_type == "application/vnd.ms-excel"
             )
 
         if not should_process:


### PR DESCRIPTION
…s) because their MIME type ('application/vnd.ms-excel') was not included in the list of processable text-based formats. This commit adds the MIME type to the `should_process` check in `main.py`, ensuring that `.xls` files are now correctly queued for all text-based analysis tasks, such as summarization and password detection.