### PR TITLE
feat: Add sorting to generate_stats.py

### DIFF
--- a/scripts/generate_stats.py
+++ b/scripts/generate_stats.py
@@ -133,7 +133,6 @@ def generate_stats(
     # --- Sorting Logic ---
     mime_type_items = completed_stats["files_by_mime_type"].items()
     if sort_by:
-        sort_by = sort_by.lower()
         if sort_by == "mime type":
             mime_type_items = sorted(mime_type_items, key=lambda item: item[0])
         elif sort_by == "total":
@@ -148,13 +147,6 @@ def generate_stats(
             mime_type_items = sorted(
                 mime_type_items, key=lambda item: item[1]["without_text"], reverse=True
             )
-        else:
-            console.print(
-                f"[bold red]Invalid sort column: {sort_by}. "
-                "Valid columns are 'mime type', 'total', 'with text', "
-                "'without text'.[/bold red]"
-            )
-            raise typer.Exit(code=1)
 
     mime_table = Table(title="Files by MIME Type")
     mime_table.add_column("MIME Type", style="cyan")

--- a/scripts/generate_stats.py
+++ b/scripts/generate_stats.py
@@ -35,6 +35,15 @@ def generate_stats(
         dir_okay=False,
         readable=True,
     ),
+    sort_by: str = typer.Option(
+        None,
+        "--sort-by",
+        "-s",
+        help="Sort the MIME type table by a specific column.",
+        case_sensitive=False,
+        show_choices=True,
+        rich_help_panel="Sorting Options",
+    ),
 ):
     """
     Generate statistics from the manifest file.
@@ -120,12 +129,37 @@ def generate_stats(
         f"\n[bold]Statistics for {completed_stats['total']} completed files:[/bold]"
     )
 
+    # --- Sorting Logic ---
+    mime_type_items = completed_stats["files_by_mime_type"].items()
+    if sort_by:
+        sort_by = sort_by.lower()
+        if sort_by == "mime type":
+            mime_type_items = sorted(mime_type_items, key=lambda item: item[0])
+        elif sort_by == "total":
+            mime_type_items = sorted(
+                mime_type_items, key=lambda item: item[1]["total"], reverse=True
+            )
+        elif sort_by == "with text":
+            mime_type_items = sorted(
+                mime_type_items, key=lambda item: item[1]["with_text"], reverse=True
+            )
+        elif sort_by == "without text":
+            mime_type_items = sorted(
+                mime_type_items, key=lambda item: item[1]["without_text"], reverse=True
+            )
+        else:
+            console.print(
+                f"[bold red]Invalid sort column: {sort_by}. "
+                "Valid columns are 'MIME Type', 'Total', 'With Text', "
+                "'Without Text'.[/bold red]"
+            )
+
     mime_table = Table(title="Files by MIME Type")
     mime_table.add_column("MIME Type", style="cyan")
     mime_table.add_column("Total", style="magenta")
     mime_table.add_column("With Text", style="green")
     mime_table.add_column("Without Text", style="red")
-    for mime_type, mime_stats in completed_stats["files_by_mime_type"].items():
+    for mime_type, mime_stats in mime_type_items:
         mime_table.add_row(
             mime_type,
             str(mime_stats["total"]),

--- a/scripts/generate_stats.py
+++ b/scripts/generate_stats.py
@@ -42,6 +42,7 @@ def generate_stats(
         help="Sort the MIME type table by a specific column.",
         case_sensitive=False,
         show_choices=True,
+        choices=["mime type", "total", "with text", "without text"],
         rich_help_panel="Sorting Options",
     ),
 ):
@@ -150,9 +151,10 @@ def generate_stats(
         else:
             console.print(
                 f"[bold red]Invalid sort column: {sort_by}. "
-                "Valid columns are 'MIME Type', 'Total', 'With Text', "
-                "'Without Text'.[/bold red]"
+                "Valid columns are 'mime type', 'total', 'with text', "
+                "'without text'.[/bold red]"
             )
+            raise typer.Exit(code=1)
 
     mime_table = Table(title="Files by MIME Type")
     mime_table.add_column("MIME Type", style="cyan")


### PR DESCRIPTION
This PR adds a --sort-by flag to the generate_stats.py script to allow sorting the MIME type table by a specific column.